### PR TITLE
fix(monitoring): add host labels, fix journal relabel, remove dashboard job filter

### DIFF
--- a/modules/nixos/homelab/alloy.nix
+++ b/modules/nixos/homelab/alloy.nix
@@ -20,22 +20,25 @@ let
     // ----------------------------------------------------------------
     // Local: ship vanaheim's own systemd journal to Loki
     // ----------------------------------------------------------------
+    // relabel_rules are consumed by loki.source.journal below; forward_to
+    // is empty because the rules are referenced, not chained.
+    loki.relabel "journal" {
+      forward_to = []
+
+      rule {
+        source_labels = ["__journal__systemd_unit"]
+        target_label  = "unit"
+      }
+    }
+
     loki.source.journal "system" {
       max_age    = "12h"
       labels     = {
         job  = "systemd-journal",
         host = constants.hostname,
       }
-      forward_to = [loki.relabel.journal.receiver]
-    }
-
-    loki.relabel "journal" {
-      forward_to = [loki.write.local.receiver]
-
-      rule {
-        source_labels = ["__journal__systemd_unit"]
-        target_label  = "unit"
-      }
+      forward_to    = [loki.write.local.receiver]
+      relabel_rules = loki.relabel.journal.rules
     }
 
     loki.write "local" {

--- a/modules/nixos/homelab/grafana.nix
+++ b/modules/nixos/homelab/grafana.nix
@@ -34,6 +34,29 @@ let
     # Dropdown to filter by systemd unit
     templating.list = [
       {
+        name = "host";
+        label = "Host";
+        type = "query";
+        datasource = {
+          type = "loki";
+          uid = lokiUid;
+        };
+        definition = "label_values({job=\"systemd-journal\"},host)";
+        query = {
+          query = "label_values({job=\"systemd-journal\"},host)";
+          refId = "LokiVariableQueryEditor-VariableQuery";
+        };
+        refresh = 2;
+        multi = true;
+        includeAll = true;
+        allValue = ".+";
+        current = {
+          selected = true;
+          text = "All";
+          value = "$__all";
+        };
+      }
+      {
         name = "unit";
         label = "Unit";
         type = "query";
@@ -41,9 +64,9 @@ let
           type = "loki";
           uid = lokiUid;
         };
-        definition = "label_values({job=\"systemd-journal\",host=\"vanaheim\"},unit)";
+        definition = "label_values({job=\"systemd-journal\",host=~\"$host\"},unit)";
         query = {
-          query = "label_values({job=\"systemd-journal\",host=\"vanaheim\"},unit)";
+          query = "label_values({job=\"systemd-journal\",host=~\"$host\"},unit)";
           refId = "LokiVariableQueryEditor-VariableQuery";
         };
         refresh = 2;
@@ -76,7 +99,7 @@ let
               type = "loki";
               uid = lokiUid;
             };
-            expr = "sum by(unit) (rate({job=\"systemd-journal\",host=\"vanaheim\",unit=~\"$unit\"}[$__rate_interval]))";
+            expr = "sum by(unit) (rate({job=\"systemd-journal\",host=~\"$host\",unit=~\"$unit\"}[$__rate_interval]))";
             legendFormat = "{{unit}}";
             refId = "A";
           }
@@ -130,7 +153,7 @@ let
               type = "loki";
               uid = lokiUid;
             };
-            expr = "{job=\"systemd-journal\",host=\"vanaheim\",unit=~\"$unit\"}";
+            expr = "{job=\"systemd-journal\",host=~\"$host\",unit=~\"$unit\"}";
             refId = "A";
           }
         ];

--- a/modules/nixos/homelab/grafana.nix
+++ b/modules/nixos/homelab/grafana.nix
@@ -12,7 +12,7 @@ let
   prometheusUid = "prometheus";
 
   # Dashboard JSON defined as a Nix attrset — serialised at build time.
-  # Labels shipped by promtail: job="systemd-journal", host=<hostname>, unit=<systemd-unit>
+  # Labels: host=<hostname> — also job="systemd-journal", unit=<systemd-unit> from vanaheim alloy
   systemLogsDashboard = {
     id = null;
     uid = "system-logs";
@@ -41,9 +41,9 @@ let
           type = "loki";
           uid = lokiUid;
         };
-        definition = "label_values({job=\"systemd-journal\"},host)";
+        definition = "label_values(host)";
         query = {
-          query = "label_values({job=\"systemd-journal\"},host)";
+          query = "label_values(host)";
           refId = "LokiVariableQueryEditor-VariableQuery";
         };
         refresh = 2;
@@ -99,8 +99,8 @@ let
               type = "loki";
               uid = lokiUid;
             };
-            expr = "sum by(unit) (rate({job=\"systemd-journal\",host=~\"$host\",unit=~\"$unit\"}[$__rate_interval]))";
-            legendFormat = "{{unit}}";
+            expr = "sum by(host) (rate({host=~\"$host\"}[$__rate_interval]))";
+            legendFormat = "{{host}}";
             refId = "A";
           }
         ];
@@ -153,7 +153,7 @@ let
               type = "loki";
               uid = lokiUid;
             };
-            expr = "{job=\"systemd-journal\",host=~\"$host\",unit=~\"$unit\"}";
+            expr = "{host=~\"$host\"}";
             refId = "A";
           }
         ];


### PR DESCRIPTION
## Changes

1. **alloy.nix: Fix systemd unit label relabel** — Switched from chained `forward_to` to using `relabel_rules` on `loki.source.journal`. `__journal__` internal labels are only accessible via `relabel_rules`, not through chained `loki.relabel` components. Fixes the missing `unit` label in Loki.

2. **grafana.nix: Add host filter variable to System Logs dashboard** — Added `host` template variable so users can filter between hosts (vanaheim, zepher) instead of being hardcoded to `host="vanaheim"`.

3. **grafana.nix: Remove job filter from dashboard queries** — The `job="systemd-journal"` filter in host variable, Log Rate, and Log Lines panels excluded zepher Docker logs (which have no `job` label). Removed it so all hosts' logs are visible.

## Verification
- All services (loki, alloy, prometheus, alertmanager, grafana) running on vanaheim
- `unit` label now populated in Loki (alloy.service, sshd.service, etc.)
- Loki `host` label now shows both `vanaheim` and `zepher`
- Grafana datasources healthy (Loki + Prometheus)
- Deployed to vanaheim and confirmed working
